### PR TITLE
Add entrypoint support

### DIFF
--- a/numba_scipy/__init__.py
+++ b/numba_scipy/__init__.py
@@ -2,3 +2,11 @@
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+
+def _init_extension():
+    '''Register SciPy functions with Numba.
+
+    This entry_point is called by Numba when it initializes.
+    '''
+    from . import special

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,11 @@ metadata = dict(
     packages=['numba_scipy'],
     setup_requires=[],
     install_requires=_install_requires,
+    entry_points={
+        "numba_extensions": [
+            "init = numba_scipy:_init_extension",
+        ],
+    },
     license="BSD",
     zip_safe=False,
     )


### PR DESCRIPTION
Uses numba/numba#4427 to automatically register the scipy overloads with Numba even without the user having to import `numba_scipy` directly.