### PR TITLE
Use hypothesis for tests

### DIFF
--- a/numba_scipy/tests/test_special.py
+++ b/numba_scipy/tests/test_special.py
@@ -1,17 +1,31 @@
 """Tests the scipy.special bindings
 """
-import numba_scipy.special # noqa
+import numba_scipy.special  # noqa
 from scipy.special import beta
 from numba import njit
 import numpy as np
 
+from hypothesis import given, settings
+import hypothesis.strategies as st
+from hypothesis.extra.numpy import arrays as st_arrays
 
-def test_beta():
 
+@given(st.floats(0, 20), st.floats(0, 20))
+def test_beta_scalars(x, y):
     @njit
     def test_impl(a, b):
         return beta(a, b)
 
-    x = np.linspace(0, 20, 50)
-    y = x[::-1]
+    np.testing.assert_allclose(test_impl(x, y), test_impl.py_func(x, y))
+
+
+@given(
+    st_arrays(np.float, 10, st.floats(0, 20)), st_arrays(np.float, 10, st.floats(0, 20))
+)
+@settings(deadline=None)
+def test_beta_arrays(x, y):
+    @njit
+    def test_impl(a, b):
+        return beta(a, b)
+
     np.testing.assert_allclose(test_impl(x, y), test_impl.py_func(x, y))


### PR DESCRIPTION
A humble proposal to use [Hypothesis](https://hypothesis.readthedocs.io/) for the tests. It will likely make them more robust, and going forward help the developers catch corner cases (like `np.nan`, `np.inf`, etc).