### PR TITLE
try to make anaconda client work

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -117,4 +117,4 @@ jobs:
           ls -la ./artifact_storage
           UPLOAD=$(ls ./artifact_storage | head -1)
           echo "Uploading $UPLOAD with label=${{ env.AC_LABEL }}"
-          $CONDA/bin/anaconda -t ${{ secrets.ANACONDA_ORG_TOKEN }} upload -u numba -l ${{ env.AC_LABEL }} --no-progress --force --no-register ./artifact_storage/$UPLOAD
+          anaconda -t ${{ secrets.ANACONDA_ORG_TOKEN }} upload -u numba -l ${{ env.AC_LABEL }} --no-progress --force --no-register ./artifact_storage/$UPLOAD


### PR DESCRIPTION
This hopefully fixes:

```
Uploading numba-scipy-0.3.0dev0-py_15.tar.bz2 with label=dev
/home/runner/work/_temp/31ff367a-b22d-47f5-963f-0d92819d59dc.sh: line 5: /usr/share/miniconda/bin/anaconda: No such file or directory
```