### PR TITLE
setup.py: numba-scipy is verified to work with scipy-1.7.3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 import versioneer
 
 
-_install_requires = ['scipy>=0.16,<=1.7.1', 'numba>=0.45']
+_install_requires = ['scipy>=0.16,<=1.7.3', 'numba>=0.45']
 
 
 metadata = dict(


### PR DESCRIPTION
Hi, I have tested numba-scipy againest scipy-1.7.3.  It works as expected.

See also: https://github.com/jiegec/gentoo-pypi-sci/tree/master/dev-python/numba-scipy