### PR TITLE
Continue PR #76: Upgrade scipy to 1.7.3

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scipy-version: [">=0.16,<1.4", ">=1.4,<=1.7.1"]
+        scipy-version: [">=0.16,<1.4", ">=1.4,<=1.7.3"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        scipy-version: [">=0.16,<1.4", ">=1.4,<=1.7.1"]
+        scipy-version: [">=0.16,<1.4", ">=1.4,<=1.7.3"]
         pyver: [3.6, 3.7, 3.8]
         runs-on: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.runs-on }}

--- a/buildscripts/conda_recipes/numba-scipy/meta.yaml
+++ b/buildscripts/conda_recipes/numba-scipy/meta.yaml
@@ -18,16 +18,16 @@ requirements:
   host:
     - python
     - numba
-    - scipy<=1.7.1
+    - scipy<=1.7.3
     - setuptools
   run:
     - python
     - numba
-    - scipy<=1.7.1
+    - scipy<=1.7.3
 
 test:
   requires:
-    - scipy<=1.7.1
+    - scipy<=1.7.3
     - pytest
     - setuptools
     - faulthandler             # [py27 and (not (armv6l or armv7l))]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 import versioneer
 
 
-_install_requires = ['scipy>=0.16,<=1.7.1', 'numba>=0.45']
+_install_requires = ['scipy>=0.16,<=1.7.3', 'numba>=0.45']
 
 
 metadata = dict(


### PR DESCRIPTION
(closes #76)

Continuation of #76. 

Requires #79 for Azure vmImage update.

This will enable Python3.10