### PR TITLE
fix the label for uploading tags

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Determine label
         if: contains(github.ref, 'refs/tags/')
         run: |
-          echo "AC_LABEL=numba/label/dev" >> $GITHUB_ENV
+          echo "AC_LABEL=main" >> $GITHUB_ENV
       - name: Deploy to Anaconda Cloud
         shell: bash -l {0}
         # workaround issues with setup-miniconda an anaconda-client


### PR DESCRIPTION
This fixes the upload of tags to `numba/label/main` channel on
anaconda.org. Previously, tags would be uploaded to:
`numba/label/numba/label/dev` which would show up in the webinterface as
`numba/label/dev` and not just `dev`. But, we also want tags to arive on
`numba/label/main` so we use `main` as argument for the final upload
command, which will be along the lines of:

```
anaconda upload -u numba -l main ...
```