### PR TITLE
Bump scipy version to <1.11.0

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -90,56 +90,6 @@ jobs:
             scipy-version: ">=0.16,<1.4"
             numpy-version: "<1.22.0"
             runs-on: windows-latest
-          # numpy >= 1.22 not supported by scipy <= 1.7.3
-          # scipy >=1.8.0 only support python >=3.8
-          - pyver: 3.6
-            scipy-version: ">=0.16,<1.4"
-            numpy-version: "<1.22.0"
-            runs-on: macos-latest
-          - pyver: 3.6
-            scipy-version: ">=1.4,<=1.7.3"
-            numpy-version: "<1.22.0"
-            runs-on: macos-latest
-          - pyver: 3.6
-            scipy-version: ">=0.16,<1.4"
-            numpy-version: "<1.22.0"
-            runs-on: ubuntu-latest
-          - pyver: 3.6
-            scipy-version: ">=1.4,<=1.7.3"
-            numpy-version: "<1.22.0"
-            runs-on: ubuntu-latest
-          - pyver: 3.6
-            scipy-version: ">=0.16,<1.4"
-            numpy-version: "<1.22.0"
-            runs-on: windows-latest
-          - pyver: 3.6
-            scipy-version: ">=1.4,<=1.7.3"
-            numpy-version: "<1.22.0"
-            runs-on: windows-latest
-          - pyver: 3.7
-            scipy-version: ">=0.16,<1.4"
-            numpy-version: "<1.22.0"
-            runs-on: macos-latest
-          - pyver: 3.7
-            scipy-version: ">=1.4,<=1.7.3"
-            numpy-version: "<1.22.0"
-            runs-on: macos-latest
-          - pyver: 3.7
-            scipy-version: ">=0.16,<1.4"
-            numpy-version: "<1.22.0"
-            runs-on: ubuntu-latest
-          - pyver: 3.7
-            scipy-version: ">=1.4,<=1.7.3"
-            numpy-version: "<1.22.0"
-            runs-on: ubuntu-latest
-          - pyver: 3.7
-            scipy-version: ">=0.16,<1.4"
-            numpy-version: "<1.22.0"
-            runs-on: windows-latest
-          - pyver: 3.7
-            scipy-version: ">=1.4,<=1.7.3"
-            numpy-version: "<1.22.0"
-            runs-on: windows-latest
 
     runs-on: ${{ matrix.runs-on }}
     steps:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -78,20 +78,65 @@ jobs:
           - pyver: 3.8
             scipy-version: ">=0.16,<1.4"
             numpy-version: "<1.22.0"
+            runs-on: macos-latest
+          - pyver: 3.8
+            scipy-version: ">=0.16,<1.4"
+            numpy-version: "<1.22.0"
+            runs-on: ubuntu-latest
+          - pyver: 3.8
+            scipy-version: ">=0.16,<1.4"
+            numpy-version: "<1.22.0"
+            runs-on: windows-latest
           # numpy >= 1.22 not supported by scipy <= 1.7.3
           # scipy >=1.8.0 only support python >=3.8
           - pyver: 3.6
             scipy-version: ">=0.16,<1.4"
             numpy-version: "<1.22.0"
+            runs-on: macos-latest
           - pyver: 3.6
             scipy-version: ">=1.4,<=1.7.3"
             numpy-version: "<1.22.0"
+            runs-on: macos-latest
+          - pyver: 3.6
+            scipy-version: ">=0.16,<1.4"
+            numpy-version: "<1.22.0"
+            runs-on: ubuntu-latest
+          - pyver: 3.6
+            scipy-version: ">=1.4,<=1.7.3"
+            numpy-version: "<1.22.0"
+            runs-on: ubuntu-latest
+          - pyver: 3.6
+            scipy-version: ">=0.16,<1.4"
+            numpy-version: "<1.22.0"
+            runs-on: windows-latest
+          - pyver: 3.6
+            scipy-version: ">=1.4,<=1.7.3"
+            numpy-version: "<1.22.0"
+            runs-on: windows-latest
           - pyver: 3.7
             scipy-version: ">=0.16,<1.4"
             numpy-version: "<1.22.0"
+            runs-on: macos-latest
           - pyver: 3.7
             scipy-version: ">=1.4,<=1.7.3"
             numpy-version: "<1.22.0"
+            runs-on: macos-latest
+          - pyver: 3.7
+            scipy-version: ">=0.16,<1.4"
+            numpy-version: "<1.22.0"
+            runs-on: ubuntu-latest
+          - pyver: 3.7
+            scipy-version: ">=1.4,<=1.7.3"
+            numpy-version: "<1.22.0"
+            runs-on: ubuntu-latest
+          - pyver: 3.7
+            scipy-version: ">=0.16,<1.4"
+            numpy-version: "<1.22.0"
+            runs-on: windows-latest
+          - pyver: 3.7
+            scipy-version: ">=1.4,<=1.7.3"
+            numpy-version: "<1.22.0"
+            runs-on: windows-latest
 
     runs-on: ${{ matrix.runs-on }}
     steps:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -11,19 +11,15 @@ on:
       - '*'
 
 env:
-  MAIN_PYVER: 3.8
+  MAIN_PYVER: "3.10"
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scipy-version: [">=0.16,<1.4", ">=1.4,<1.11.0"]
-        include:
-          - scipy-version: ">=0.16,<1.4"
-            numpy-version: "<1.22.0"
-          - scipy-version: ">=1.4,<1.11.0"
-            numpy-version: ">=1.22.0"
+        scipy-version: [">=1.4,<1.11.0"]
+        numpy-version: ["<1.22.0", ">=1.22.0"]
     steps:
       - name: Install glibc-tools
         shell: bash -l {0}
@@ -74,17 +70,27 @@ jobs:
     needs: build
     strategy:
       matrix:
-        scipy-version: [">=0.16,<1.4", ">=1.4,<1.11.0"]
-        pyver: [3.6, 3.7, 3.8, 3.9, "3.10", 3.11]
+        scipy-version: [">=1.4,<1.11.0"]
+        pyver: [3.8, 3.9, "3.10", 3.11]
         runs-on: [macos-latest, ubuntu-latest, windows-latest]
+        numpy-version: ["<1.22.0", ">=1.22.0"]
         include:
-          - scipy-version: ">=0.16,<1.4"
+          - pyver: 3.8
+            scipy-version: ">=0.16,<1.4"
             numpy-version: "<1.22.0"
-          - scipy-version: ">=1.4,<1.11.0"
-            numpy-version: ">=1.22.0"
+          # numpy >= 1.22 not supported by scipy <= 1.7.3
+          # scipy >=1.8.0 only support python >=3.8
           - pyver: 3.6
+            scipy-version: ">=0.16,<1.4"
+            numpy-version: "<1.22.0"
+          - pyver: 3.6
+            scipy-version: ">=1.4,<=1.7.3"
             numpy-version: "<1.22.0"
           - pyver: 3.7
+            scipy-version: ">=0.16,<1.4"
+            numpy-version: "<1.22.0"
+          - pyver: 3.7
+            scipy-version: ">=1.4,<=1.7.3"
             numpy-version: "<1.22.0"
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       matrix:
         scipy-version: [">=0.16,<1.4", ">=1.4,<1.11.0"]
-        pyver: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
+        pyver: [3.6, 3.7, 3.8, 3.9, "3.10", 3.11]
         runs-on: [macos-latest, ubuntu-latest, windows-latest]
         include:
           - scipy-version: ">=0.16,<1.4"

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scipy-version: [">=0.16,<1.4", ">=1.4,<1.10.0"]
+        scipy-version: [">=0.16,<1.4", ">=1.4,<1.11.0"]
     steps:
       - name: Install glibc-tools
         shell: bash -l {0}
@@ -69,7 +69,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        scipy-version: [">=0.16,<1.4", ">=1.4,<1.10.0"]
+        scipy-version: [">=0.16,<1.4", ">=1.4,<1.11.0"]
         pyver: [3.6, 3.7, 3.8]
         runs-on: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -75,13 +75,18 @@ jobs:
     strategy:
       matrix:
         scipy-version: [">=0.16,<1.4", ">=1.4,<1.11.0"]
-        pyver: [3.6, 3.7, 3.8]
+        pyver: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
         runs-on: [macos-latest, ubuntu-latest, windows-latest]
         include:
           - scipy-version: ">=0.16,<1.4"
             numpy-version: "<1.22.0"
           - scipy-version: ">=1.4,<1.11.0"
             numpy-version: ">=1.22.0"
+          - pyver: 3.6
+            numpy-version: "<1.22.0"
+          - pyver: 3.7
+            numpy-version: "<1.22.0"
+
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Download build artifact

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -19,6 +19,11 @@ jobs:
     strategy:
       matrix:
         scipy-version: [">=0.16,<1.4", ">=1.4,<1.11.0"]
+        include:
+          - scipy-version: ">=0.16,<1.4"
+            numpy-version: "<1.22.0"
+          - scipy-version: ">=1.4,<1.11.0"
+            numpy-version: ">=1.22.0"
     steps:
       - name: Install glibc-tools
         shell: bash -l {0}
@@ -39,7 +44,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install -c numba conda-build python=${{ env.MAIN_PYVER }} numba>=0.45 'scipy${{ matrix.scipy-version }}' flake8 pytest pip
+          conda install -c numba conda-build python=${{ env.MAIN_PYVER }} numba>=0.45 'scipy${{ matrix.scipy-version }}' 'numpy${{ matrix.numpy-version }}' flake8 pytest pip
           pip install --no-deps -e .
       - name: Lint with flake8
         shell: bash -l {0}
@@ -72,6 +77,11 @@ jobs:
         scipy-version: [">=0.16,<1.4", ">=1.4,<1.11.0"]
         pyver: [3.6, 3.7, 3.8]
         runs-on: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - scipy-version: ">=0.16,<1.4"
+            numpy-version: "<1.22.0"
+          - scipy-version: ">=1.4,<1.11.0"
+            numpy-version: ">=1.22.0"
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Download build artifact
@@ -88,7 +98,7 @@ jobs:
       - name: Install dependencies and build artifact
         shell: bash -l {0}
         run: |
-          conda install -c numba python=${{ matrix.pyver }} numba>=0.45 'scipy${{ matrix.scipy-version }}' flake8 pytest
+          conda install -c numba python=${{ matrix.pyver }} numba>=0.45 'scipy${{ matrix.scipy-version }}' 'numpy${{ matrix.numpy-version }}' flake8 pytest
           # Install built_package
           BUILT_PKG=$(ls ./artifact_storage | head -1)
           conda install ./artifact_storage/$BUILT_PKG

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -74,6 +74,9 @@ jobs:
         pyver: [3.8, 3.9, "3.10", 3.11]
         runs-on: [macos-latest, ubuntu-latest, windows-latest]
         numpy-version: ["<1.22.0", ">=1.22.0"]
+        exclude:
+          - pyver: 3.11
+            numpy-version: "<1.22.0"
         include:
           - pyver: 3.8
             scipy-version: ">=0.16,<1.4"

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scipy-version: [">=0.16,<1.4", ">=1.4,<=1.7.3"]
+        scipy-version: [">=0.16,<1.4", ">=1.4,<1.10.0"]
     steps:
       - name: Install glibc-tools
         shell: bash -l {0}
@@ -69,7 +69,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        scipy-version: [">=0.16,<1.4", ">=1.4,<=1.7.3"]
+        scipy-version: [">=0.16,<1.4", ">=1.4,<1.10.0"]
         pyver: [3.6, 3.7, 3.8]
         runs-on: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.runs-on }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,26 +5,20 @@ jobs:
     name: Linux
     vmImage: ubuntu-22.04
     matrix:
-      py310_np124_sp1_10:
-        PYTHON: '3.10'
-        NUMPY: '1.24'
-        SCIPY: '1.10'
-        CONDA_ENV: 'testenv'
-      py310_np123_sp1_10_32bit:
+      py310_np123_sp1_10:
         PYTHON: '3.10'
         NUMPY: '1.23'
         SCIPY: '1.10'
         CONDA_ENV: 'testenv'
-        BITS32: yes
 
 - template: buildscripts/azure/azure-linux-macos.yml
   parameters:
     name: macOS
     vmImage: macOS-latest
     matrix:
-      py310_np124_sp1_10:
+      py310_np123_sp1_10:
         PYTHON: '3.10'
-        NUMPY: '1.24'
+        NUMPY: '1.23'
         SCIPY: '1.10'
         CONDA_ENV: 'testenv'
 
@@ -33,8 +27,8 @@ jobs:
     name: Windows
     vmImage: windows-2019
     matrix:
-      py310_np124_sp1_10:
+      py310_np123_sp1_10:
         PYTHON: '3.10'
-        NUMPY: '1.24'
+        NUMPY: '1.23'
         SCIPY: '1.10'
         CONDA_ENV: 'testenv'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
 - template: buildscripts/azure/azure-linux-macos.yml
   parameters:
     name: macOS
-    vmImage: macOS-10.15
+    vmImage: macOS-latest
     matrix:
       py37_np116_sp11:
         PYTHON: '3.7'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,15 +5,15 @@ jobs:
     name: Linux
     vmImage: ubuntu-22.04
     matrix:
-      py37_np116_sp11:
-        PYTHON: '3.7'
-        NUMPY: '1.16'
-        SCIPY: '1.1'
+      py310_np124_sp1_10:
+        PYTHON: '3.10'
+        NUMPY: '1.24'
+        SCIPY: '1.10'
         CONDA_ENV: 'testenv'
-      py37_np115_sp11_32bit:
-        PYTHON: '3.7'
-        NUMPY: '1.15'
-        SCIPY: '1.1'
+      py310_np123_sp1_10_32bit:
+        PYTHON: '3.10'
+        NUMPY: '1.23'
+        SCIPY: '1.10'
         CONDA_ENV: 'testenv'
         BITS32: yes
 
@@ -22,10 +22,10 @@ jobs:
     name: macOS
     vmImage: macOS-latest
     matrix:
-      py37_np116_sp11:
-        PYTHON: '3.7'
-        NUMPY: '1.16'
-        SCIPY: '1.1'
+      py310_np124_sp1_10:
+        PYTHON: '3.10'
+        NUMPY: '1.24'
+        SCIPY: '1.10'
         CONDA_ENV: 'testenv'
 
 - template: buildscripts/azure/azure-windows.yml
@@ -33,8 +33,8 @@ jobs:
     name: Windows
     vmImage: windows-2019
     matrix:
-      py37_np116_sp11:
-        PYTHON: '3.7'
-        NUMPY: '1.16'
-        SCIPY: '1.1'
+      py310_np124_sp1_10:
+        PYTHON: '3.10'
+        NUMPY: '1.24'
+        SCIPY: '1.10'
         CONDA_ENV: 'testenv'

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -15,7 +15,7 @@ jobs:
   steps:
     - script: |
         if [ "$(uname)" == "Linux" ] && [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" ]]; then sudo apt-get install -y libc6-dev-i386; fi
-        if [ "$(uname)" == "Linux" ] && [[ "$CONDA_SUBDIR" == "linux-64" || "$BITS32" == "no" ]]; then sudo apt-get install -y glibc-tools; fi
+        if [ "$(uname)" == "Linux" ] && [[ "$CONDA_SUBDIR" != "linux-32" || "$BITS32" != "yes" ]]; then sudo apt-get install -y glibc-tools; fi
         echo "Installing Miniconda"
         buildscripts/incremental/install_miniconda.sh
         export PATH=$HOME/miniconda3/bin:$PATH

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -15,6 +15,7 @@ jobs:
   steps:
     - script: |
         if [ "$(uname)" == "Linux" ] && [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" ]]; then sudo apt-get install -y libc6-dev-i386; fi
+        if [ "$(uname)" == "Linux" ] && [[ "$CONDA_SUBDIR" == "linux" || "$BITS32" == "no" ]]; then sudo apt-get install -y glibc-tools; fi
         echo "Installing Miniconda"
         buildscripts/incremental/install_miniconda.sh
         export PATH=$HOME/miniconda3/bin:$PATH

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -15,7 +15,7 @@ jobs:
   steps:
     - script: |
         if [ "$(uname)" == "Linux" ] && [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" ]]; then sudo apt-get install -y libc6-dev-i386; fi
-        if [ "$(uname)" == "Linux" ] && [[ "$CONDA_SUBDIR" == "linux" || "$BITS32" == "no" ]]; then sudo apt-get install -y glibc-tools; fi
+        if [ "$(uname)" == "Linux" ] && [[ "$CONDA_SUBDIR" == "linux-64" || "$BITS32" == "no" ]]; then sudo apt-get install -y glibc-tools; fi
         echo "Installing Miniconda"
         buildscripts/incremental/install_miniconda.sh
         export PATH=$HOME/miniconda3/bin:$PATH

--- a/buildscripts/conda_recipes/numba-scipy/meta.yaml
+++ b/buildscripts/conda_recipes/numba-scipy/meta.yaml
@@ -18,16 +18,16 @@ requirements:
   host:
     - python
     - numba
-    - scipy<1.10.0
+    - scipy<1.11.0
     - setuptools
   run:
     - python
     - numba
-    - scipy<1.10.0
+    - scipy<1.11.0
 
 test:
   requires:
-    - scipy<1.10.0
+    - scipy<1.11.0
     - pytest
     - setuptools
     - faulthandler             # [py27 and (not (armv6l or armv7l))]

--- a/buildscripts/conda_recipes/numba-scipy/meta.yaml
+++ b/buildscripts/conda_recipes/numba-scipy/meta.yaml
@@ -18,16 +18,16 @@ requirements:
   host:
     - python
     - numba
-    - scipy<=1.7.3
+    - scipy<1.10.0
     - setuptools
   run:
     - python
     - numba
-    - scipy<=1.7.3
+    - scipy<1.10.0
 
 test:
   requires:
-    - scipy<=1.7.3
+    - scipy<1.10.0
     - pytest
     - setuptools
     - faulthandler             # [py27 and (not (armv6l or armv7l))]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 import versioneer
 
 
-_install_requires = ['scipy>=0.16,<=1.7.3', 'numba>=0.45']
+_install_requires = ['scipy>=0.16,<=1.11.0', 'numba>=0.45']
 
 
 metadata = dict(

--- a/setup.py
+++ b/setup.py
@@ -2,25 +2,24 @@ from setuptools import setup, find_packages
 import versioneer
 
 
-_install_requires = ['scipy>=0.16,<=1.11.0', 'numba>=0.45']
+_install_requires = ["scipy>=0.16,<=1.11.0", "numba>=0.45"]
 
 
 metadata = dict(
-    name='numba-scipy',
+    name="numba-scipy",
     description="numba-scipy extends Numba to make it aware of SciPy",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Compilers",
     ],
     package_data={},
@@ -42,8 +41,8 @@ metadata = dict(
 )
 
 
-with open('README.rst') as f:
-    metadata['long_description'] = f.read()
+with open("README.rst") as f:
+    metadata["long_description"] = f.read()
 
 
 setup(**metadata)


### PR DESCRIPTION
This PR bumps scipy version to allow installation of numpy >=1.23 alongside numba and numba-scipy

As discussed in #88 the scipy upgrade was waiting for anaconda to have a later release in its default repo which it now does (https://anaconda.org/anaconda/scipy).

I have pinned to less than the next minor version of scipy as it is unlikely behaviour will change on patch version changes. If you would like this stricter let me know.

Closes #88 

EDIT

Scipy have bumped the deprecation to after 1.11.0 (see https://github.com/scipy/scipy/issues/15596)  and 1.10.0 is now on the anaconda repo.
