### PR TITLE
Add verbose logging support for debugging Cython signature mappings in numba_scipy.special

### DIFF
--- a/numba_scipy/special/__init__.py
+++ b/numba_scipy/special/__init__.py
@@ -1,3 +1,17 @@
-from . import overloads as _overloads
+import logging
+
+logger = logging.getLogger("numba_scipy.special")
+handler = logging.StreamHandler()
+formatter = logging.Formatter("[%(levelname)s] %(name)s: %(message)s")
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)  # Change to logging.DEBUG for more verbosity
+
+from . import overloads
 
 _overloads.add_overloads()
+
+def set_verbose_logging(enabled=True):
+    level = logging.DEBUG if enabled else logging.INFO
+    logger.setLevel(level)
+    logger.info(f"Verbose logging {'enabled' if enabled else 'disabled'}")

--- a/numba_scipy/special/overloads.py
+++ b/numba_scipy/special/overloads.py
@@ -1,23 +1,40 @@
+import logging
 import numba
 import scipy.special as sc
 
 from . import signatures
 
+logger = logging.getLogger("numba_scipy.special.overloads")
 
 def choose_kernel(name, all_signatures):
 
     def choice_function(*args):
+        logger.debug(f"Choosing kernel for function '{name}' with args types: {args}")
         for signature in all_signatures:
             if args == signature:
+                logger.info(f"Found matching signature {signature} for function '{name}'")
                 f = signatures.name_and_types_to_pointer[(name, *signature)]
+                if f is None:
+                    logger.error(f"No function pointer found for {name} with signature {signature}")
+                    raise RuntimeError(f"Missing function pointer for {name} with signature {signature}")
                 return lambda *args: f(*args)
+        logger.warning(f"No matching signature found for {name} with args types {args}")
+        # Optional fallback or raise error here if no match found
+        raise TypeError(f"No matching kernel found for {name} with args {args}")
 
     return choice_function
 
 
 def add_overloads():
+    logger.info("Adding overloads for scipy.special functions")
     for name, all_signatures in signatures.name_to_numba_signatures.items():
-        sc_function = getattr(sc, name)
+        logger.debug(f"Adding overload for function: {name} with signatures: {all_signatures}")
+        try:
+            sc_function = getattr(sc, name)
+        except AttributeError:
+            logger.warning(f"scipy.special has no function named '{name}', skipping")
+            continue
         numba.extending.overload(sc_function)(
             choose_kernel(name, all_signatures)
         )
+    logger.info("Finished adding overloads")

--- a/numba_scipy/special/signatures.py
+++ b/numba_scipy/special/signatures.py
@@ -19,6 +19,8 @@ NUMBA_TO_CTYPES = {
     numba.types.long_: ctypes.c_long,
 }
 
+logger = logging.getLogger("numba_scipy.special.signatures")
+
 
 def parse_capsule_name(capsule):
     logger.debug(f"Parsing capsule name: {calsule}")


### PR DESCRIPTION
This PR introduces verbose logging across key files within numba_scipy.special, including:
__init__.py: Initializes a project-wide logger for the numba_scipy.special namespace.
signatures.py: Adds detailed logging to assist in debugging, parsing and translation of Cython signatures to Numba equivalents.
overloads.py: [Optionally added] Logs which overloads are being registered and any issues encountered during kernel selection.